### PR TITLE
Add TSV writer and update other writers' docs

### DIFF
--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -428,6 +428,28 @@ a context to a file:
 - :func:`curies.write_shacl`
 - :func:`curies.write_tsv`
 
+Here's a self-contained example on how this works:
+
+.. code-block:: python
+
+        import curies
+        converter = curies.load_prefix_map({
+            "CHEBI": "http://purl.obolibrary.org/obo/CHEBI_",
+        })
+        curies.write_shacl(converter, "example_shacl.ttl")
+
+which outputs the following file:
+
+.. code-block::
+
+    @prefix sh: <http://www.w3.org/ns/shacl#> .
+    @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+    [
+      sh:declare
+        [ sh:prefix "CHEBI" ; sh:namespace "http://purl.obolibrary.org/obo/CHEBI_"^^xsd:anyURI  ]
+    ] .
+
 Faultless handling of overlapping URI prefixes
 ----------------------------------------------
 Most implementations of URI parsing iterate through the CURIE prefix/URI prefix pairs

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -418,6 +418,16 @@ project.
 >>> converter = curies.get_bioregistry_converter()
 >>> slim_converter = converter.get_subconverter(prefixes)
 
+Writing a Context
+-----------------
+After loading and modifying a context, there are several functions for writing
+a context to a file:
+
+- :func:`curies.write_extended_prefix_map`
+- :func:`curies.write_jsonld_context`
+- :func:`curies.write_shacl`
+- :func:`curies.write_tsv`
+
 Faultless handling of overlapping URI prefixes
 ----------------------------------------------
 Most implementations of URI parsing iterate through the CURIE prefix/URI prefix pairs

--- a/src/curies/__init__.py
+++ b/src/curies/__init__.py
@@ -19,6 +19,7 @@ from .api import (
     write_extended_prefix_map,
     write_jsonld_context,
     write_shacl,
+    write_tsv,
 )
 from .discovery import discover, discover_from_rdf
 from .reconciliation import remap_curie_prefixes, remap_uri_prefixes, rewire

--- a/src/curies/__init__.py
+++ b/src/curies/__init__.py
@@ -54,6 +54,7 @@ __all__ = [
     "write_extended_prefix_map",
     "write_jsonld_context",
     "write_shacl",
+    "write_tsv",
     # sources
     "get_obo_converter",
     "get_prefixcommons_converter",

--- a/src/curies/api.py
+++ b/src/curies/api.py
@@ -2132,7 +2132,7 @@ def _ensure_path(path: Union[str, Path]) -> Path:
 
 def _get_jsonld_context(
     converter: Converter, *, expand: bool = False, include_synonyms: bool = False
-):
+) -> Dict:
     """Get a JSON-LD context based on the converter."""
     context = {}
     for record in converter.records:
@@ -2282,8 +2282,8 @@ def write_tsv(
 
     .. code-block:: csv
 
-        prefix\tbase
-        CHEBI\thttp://purl.obolibrary.org/obo/CHEBI_
+        prefix  base
+        CHEBI   http://purl.obolibrary.org/obo/CHEBI_
     """
     import csv
 

--- a/src/curies/api.py
+++ b/src/curies/api.py
@@ -62,6 +62,7 @@ __all__ = [
     "write_extended_prefix_map",
     "write_jsonld_context",
     "write_shacl",
+    "write_tsv",
 ]
 
 logger = logging.getLogger(__name__)
@@ -2259,6 +2260,40 @@ def write_shacl(
                     _get_shacl_line(prefix_synonym, record.uri_prefix, pattern=record.pattern)
                 )
     path.write_text(text.format(entries=",\n".join(lines)))
+
+
+def write_tsv(
+    converter: Converter, path: Union[str, Path], *, header: Tuple[str, str] = ("prefix", "base")
+) -> None:
+    """Write a simple prefix map CSV file.
+
+    :param converter: The converter to export
+    :param path: The path to a file to write to
+    :param header: The header used in the file, with the first element being the label
+        for CURIE prefixes and the second element being the label for URI prefixes
+
+    .. code-block:: python
+
+        import curies
+        converter = curies.load_prefix_map({
+            "CHEBI": "http://purl.obolibrary.org/obo/CHEBI_",
+        })
+        curies.write_tsv(converter, "example_context.tsv")
+
+    .. code-block:: csv
+
+        prefix\tbase
+        CHEBI\thttp://purl.obolibrary.org/obo/CHEBI_
+    """
+    import csv
+
+    path = _ensure_path(path)
+
+    with path.open("w") as csvfile:
+        writer = csv.writer(csvfile, delimiter="\t")
+        writer.writerow(header)
+        for record in converter.records:
+            writer.writerow((record.prefix, record.uri_prefix))
 
 
 def _get_shacl_line(prefix: str, uri_prefix: str, pattern: Optional[str] = None) -> str:

--- a/src/curies/api.py
+++ b/src/curies/api.py
@@ -2132,7 +2132,7 @@ def _ensure_path(path: Union[str, Path]) -> Path:
 
 def _get_jsonld_context(
     converter: Converter, *, expand: bool = False, include_synonyms: bool = False
-) -> Dict:
+) -> Dict[str, Any]:
     """Get a JSON-LD context based on the converter."""
     context = {}
     for record in converter.records:

--- a/src/curies/api.py
+++ b/src/curies/api.py
@@ -2280,7 +2280,7 @@ def write_tsv(
         })
         curies.write_tsv(converter, "example_context.tsv")
 
-    .. code-block:: csv
+    .. code-block::
 
         prefix  base
         CHEBI   http://purl.obolibrary.org/obo/CHEBI_

--- a/src/curies/api.py
+++ b/src/curies/api.py
@@ -2238,6 +2238,24 @@ def write_shacl(
         URI prefix synonyms are not output.
 
     .. seealso:: https://www.w3.org/TR/shacl/#sparql-prefixes
+
+    .. code-block:: python
+
+        import curies
+        converter = curies.load_prefix_map({
+            "CHEBI": "http://purl.obolibrary.org/obo/CHEBI_",
+        })
+        curies.write_shacl(converter, "example_shacl.ttl")
+
+    .. code-block::
+
+        @prefix sh: <http://www.w3.org/ns/shacl#> .
+        @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+        [
+          sh:declare
+            [ sh:prefix "CHEBI" ; sh:namespace "http://purl.obolibrary.org/obo/CHEBI_"^^xsd:anyURI  ]
+        ] .
     """
     text = dedent(
         """\
@@ -2269,8 +2287,9 @@ def write_tsv(
 
     :param converter: The converter to export
     :param path: The path to a file to write to
-    :param header: The header used in the file, with the first element being the label
-        for CURIE prefixes and the second element being the label for URI prefixes
+    :param header: A 2-tuple of strings representing the header used in the file,
+        where the first element is the label for CURIE prefixes and the second
+        element is the label for URI prefixes
 
     .. code-block:: python
 


### PR DESCRIPTION
Closes #106

1. Adds more docs to JSON-LD export, which supports MONDO Robot use case
2. Adds more docs to SHACL export
3. Implements simple TSV export, which supports SemanticSQL use case
4. Adds section "writing a context" into the tutorial that links to the writer functions

cc @joeflack4