### PR TITLE
Add custom model validator for CURIEs

### DIFF
--- a/docs/source/typing.rst
+++ b/docs/source/typing.rst
@@ -2,6 +2,8 @@ Typing
 ======
 This package comes with utilities for better typing other resources.
 
+Prefix Parsing
+--------------
 Let's say you have a table like this:
 
 ======  ==========  ========  ======
@@ -48,3 +50,48 @@ file and show where the error shows up:
 Note that :meth:`pydantic.BaseModel.model_validate` allows for passing a "context".
 The :class:`curies.Prefix` class implements custom context handling, so if you pass
 a converter, it knows how to check using prefixes in the converter.
+
+CURIE Parsing
+--------------
+Let's use a similar table, now with the prefix and identifier combine
+into CURIEs.
+
+===========  ========  ======
+curie        name      smiles
+===========  ========  ======
+CHEBI:16236  ethanol   CCO
+CHEBI:28831  propanol  CCCO
+CHOBI:44884  pentanol  CCCCCO
+===========  ========  ======
+
+Note that there's a typo in the prefix on the fourth row in the prefix because it
+uses ``CHOBI`` instead of ``CHEBI``. In the following code, we simulate reading that
+file and show where the error shows up:
+
+.. code-block:: python
+
+    import csv
+    from pydantic import BaseModel, ValidationError
+    from curies import Converter, Reference
+
+    converter = Converter.from_prefix_map({
+        "CHEBI": "http://purl.obolibrary.org/obo/CHEBI_",
+    })
+
+    class Row(BaseModel):
+        curie: Reference
+        name: str
+        smiles: str
+
+    records = [
+        {"curie": "CHEBI:16236", "name": "ethanol", "smiles": "CCO"},
+        {"curie": "CHEBI:28831", "name": "propanol", "smiles": "CCCO"},
+        {"curie": "CHOBI:44884", "name": "pentanol", "smiles": "CCCCCO"},
+    ]
+
+    for record in records:
+        try:
+            model = Row.model_validate(record, context=converter)
+        except ValidationError as e:
+            print(f"Issue parsing record {record}: {e}")
+            continue

--- a/src/curies/api.py
+++ b/src/curies/api.py
@@ -23,7 +23,15 @@ from typing import (
     overload,
 )
 
-from pydantic import BaseModel, ConfigDict, Field, GetCoreSchemaHandler, RootModel, field_validator
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    GetCoreSchemaHandler,
+    RootModel,
+    field_validator,
+    model_validator,
+)
 from pydantic_core import core_schema
 from pytrie import StringTrie
 from typing_extensions import Self
@@ -393,6 +401,13 @@ class Reference(BaseModel):
     )
 
     model_config = ConfigDict(frozen=True)
+
+    @model_validator(mode="before")
+    def _parse_from_string(cls, values: str | dict[str, str]) -> dict[str, str]:  # noqa:N805
+        if isinstance(values, str):
+            prefix, identifier = _split(values)
+            return {"prefix": prefix, "identifier": identifier}
+        return values
 
     def __lt__(self, other: Reference) -> bool:
         """Sort the reference lexically first by prefix, then by identifier."""

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -120,16 +120,23 @@ class TestTypes(unittest.TestCase):
 
     def test_curie(self) -> None:
         """Test a wrapped CURIE."""
-        dd = {
-            "reference": "CHEBI:1234",
-        }
-        wpm = WrappedCURIE.model_validate(dd)
+        wpm = WrappedCURIE.model_validate(
+            {
+                "reference": "CHEBI:1234",
+            }
+        )
         self.assertIn("CHEBI", wpm.reference.prefix)
         self.assertIn("1234", wpm.reference.identifier)
         self.assertIn("CHEBI:1234", wpm.reference.curie)
 
-        dd2 = {
-            "reference": "NOPENOPENOPE",
-        }
         with self.assertRaises(ValidationError):
-            WrappedCURIE.model_validate(dd2)
+            WrappedCURIE.model_validate({"reference": "NOPENOPENOPE"})
+
+        dd = {"reference": "CHEBI:1234"}
+        wpm = WrappedCURIE.model_validate(dd, context=converter)
+        self.assertIn("CHEBI", wpm.reference.prefix)
+        self.assertIn("1234", wpm.reference.identifier)
+        self.assertIn("CHEBI:1234", wpm.reference.curie)
+
+        with self.assertRaises(ValidationError):
+            WrappedCURIE.model_validate({"reference": "MONDO:1234"}, context=converter)

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -4,7 +4,7 @@ import unittest
 
 from pydantic import BaseModel, ValidationError
 
-from curies import Converter, Prefix, PrefixMap
+from curies import Converter, Prefix, PrefixMap, Reference
 
 
 class WrappedPrefix(BaseModel):
@@ -17,6 +17,12 @@ class WrappedPrefixMap(BaseModel):
     """A model wrapping a prefix map."""
 
     prefix_map: PrefixMap
+
+
+class WrappedCURIE(BaseModel):
+    """A model wrapping a reference."""
+
+    reference: Reference
 
 
 converter = Converter.from_extended_prefix_map(
@@ -111,3 +117,19 @@ class TestTypes(unittest.TestCase):
         }
         wpm = WrappedPrefixMap.model_validate(dd)
         self.assertIn("CHEBI", wpm.prefix_map.root)
+
+    def test_curie(self) -> None:
+        """Test a wrapped CURIE."""
+        dd = {
+            "reference": "CHEBI:1234",
+        }
+        wpm = WrappedCURIE.model_validate(dd)
+        self.assertIn("CHEBI", wpm.reference.prefix)
+        self.assertIn("1234", wpm.reference.identifier)
+        self.assertIn("CHEBI:1234", wpm.reference.curie)
+
+        dd2 = {
+            "reference": "NOPENOPENOPE",
+        }
+        with self.assertRaises(ValidationError):
+            WrappedCURIE.model_validate(dd2)


### PR DESCRIPTION
This PR allows for the automated parsing of string CURIEs into instances of Reference classes. This also allows for injection of a converter as context.

Here's an example:

```python
import csv
from pydantic import BaseModel, ValidationError
from curies import Converter, Reference

converter = Converter.from_prefix_map({
    "CHEBI": "http://purl.obolibrary.org/obo/CHEBI_",
})

class Row(BaseModel):
    curie: Reference
    name: str
    smiles: str

records = [
    {"curie": "CHEBI:16236", "name": "ethanol", "smiles": "CCO"},
    {"curie": "CHEBI:28831", "name": "propanol", "smiles": "CCCO"},
    {"curie": "CHOBI:44884", "name": "pentanol", "smiles": "CCCCCO"},
]

for record in records:
    try:
        model = Row.model_validate(record, context=converter)
    except ValidationError as e:
        print(f"Issue parsing record {record}: {e}")
        continue
``` 