### PR TITLE
Temporarily switch to hatchling backend

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
-requires = ["uv>=0.5.10,<0.6.0"]
-# The uv backend entered preview mode in https://github.com/astral-sh/uv/pull/8886/files
-# with the 0.5.0 release. See also https://github.com/astral-sh/uv/issues/3957 for tracking.
-build-backend = "uv"
+requires = ["hatchling"]
+build-backend = "hatchling.build"
 
 [project]
 name = "curies"

--- a/tox.ini
+++ b/tox.ini
@@ -213,6 +213,7 @@ deps =
 skip_install = true
 deps =
     uv
+    hatchling
 commands =
     uv build --sdist --wheel --no-build-isolation
 


### PR DESCRIPTION
Closes #147

Temporarily switches to hatch as a backend until https://github.com/astral-sh/uv/issues/10091 is addressed. setuptools still has a major bug with metadata upload to PyPI related to licenses between metadata version 2.3 and 2.4, so it doesn't make sense to go back to that at all.

The following should now work:

```console
$ git clone https://github.com/biopragmatics/curies
$ cd curies
$ git checkout -b hatch-backend
$ python -m pip install -e .[flask,rdflib]
$ python -m curies mapper --host 0.0.0.0 --port 8764 bioregistry

# then, navigate to http://0.0.0.0:8764/sparql
```