### PR TITLE
Add identifier standardization hook

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1198,6 +1198,44 @@ class TestConverter(unittest.TestCase):
             ),
         )
 
+    def test_standardize_identifier(self) -> None:
+        """Test standardizing identifiers."""
+
+        class BananaStripperConverter(Converter):
+            """A converter that removes bananas from LUIDs."""
+
+            def standardize_identifier(self, prefix: str, identifier: str) -> str | None:
+                norm_identifier = identifier.removeprefix(f"{prefix}:")
+
+                # now, do some validation
+                if not norm_identifier.isnumeric():
+                    return None
+
+                return norm_identifier
+
+        converter = BananaStripperConverter(
+            records=[
+                Record(
+                    prefix="CHEBI",
+                    prefix_synonyms=["chebi"],
+                    uri_prefix="http://purl.obolibrary.org/obo/CHEBI_",
+                    uri_prefix_synonyms=["https://identifiers.org/chebi:"],
+                ),
+            ]
+        )
+        self.assertEqual(ReferenceTuple("CHEBI", "1234"), converter.parse_curie("CHEBI:1234"))
+        self.assertEqual(ReferenceTuple("CHEBI", "1234"), converter.parse_curie("chebi:1234"))
+        self.assertEqual(ReferenceTuple("CHEBI", "1234"), converter.parse_curie("CHEBI:CHEBI:1234"))
+        self.assertEqual(ReferenceTuple("CHEBI", "1234"), converter.parse_curie("chebi:CHEBI:1234"))
+        self.assertIsNone(converter.parse_curie("NOPE:NOPE:1234", strict=False))
+
+        self.assertIsNone(converter.parse_curie("CHEBI:nope", strict=False))
+        # does not solve the problem of synonyms in the banana, this is specific
+        # to the current implementation in this test
+        self.assertIsNone(converter.parse_curie("chebi:chebi:1234", strict=False))
+        with self.assertRaises(ValueError):
+            converter.parse_curie("CHEBI:nope", strict=True)
+
 
 class TestVersion(unittest.TestCase):
     """Trivially test a version."""


### PR DESCRIPTION
This PR adds a function `Converter.standardize_identifier` that can be overridden to do standardization (e.g., redundant prefix stripping) or validation (e.g., against a regular expression)

By default, it's implemented as a no-op, which just returns the raw local unique identifier