### PR TITLE
Add derived reference constructor

### DIFF
--- a/src/curies/api.py
+++ b/src/curies/api.py
@@ -557,15 +557,18 @@ class NamedReference(NamableReference):
         )
 
     @classmethod
-    def from_reference(
-        cls, reference: NamedReference, *, converter: Converter | None = None
-    ) -> Self:
+    def from_reference(cls, reference: Reference, *, converter: Converter | None = None) -> Self:
         """Parse a CURIE string and populate a reference.
 
         :param reference: A pre-parsed reference
         :param converter: The converter to use as context when parsing
         :return: A reference object
         """
+        if not isinstance(reference, NamableReference):
+            raise TypeError
+        if reference.name is None:
+            raise ValueError
+
         return cls.model_validate(
             {
                 "prefix": reference.prefix,

--- a/src/curies/api.py
+++ b/src/curies/api.py
@@ -461,6 +461,16 @@ class Reference(BaseModel):
         prefix, identifier = _split(curie, sep=sep)
         return cls.model_validate({"prefix": prefix, "identifier": identifier}, context=converter)
 
+    @classmethod
+    def from_reference(cls, reference: Reference, *, converter: Converter | None = None) -> Self:
+        """Parse a CURIE string and populate a reference.
+
+        :param reference: A pre-parsed reference
+        :param converter: The converter to use as context when parsing
+        :return: A reference object
+        """
+        return cls.model_validate({"prefix": reference.prefix, "identifier": reference.identifier}, context=converter)
+
 
 class NamableReference(Reference):
     """A reference, maybe with a name."""
@@ -500,6 +510,18 @@ class NamableReference(Reference):
             {"prefix": prefix, "identifier": identifier, "name": name}, context=converter
         )
 
+    @classmethod
+    def from_reference(cls, reference: Reference, *, converter: Converter | None = None) -> Self:
+        """Parse a CURIE string and populate a reference.
+
+        :param reference: A pre-parsed reference
+        :param converter: The converter to use as context when parsing
+        :return: A reference object
+        """
+        name = reference.name if isinstance(reference, NamableReference) else None
+        return cls.model_validate({"prefix": reference.prefix, "identifier": reference.identifier, "name": name}, context=converter)
+
+
 
 class NamedReference(NamableReference):
     """A reference with a name."""
@@ -529,6 +551,17 @@ class NamedReference(NamableReference):
         return cls.model_validate(
             {"prefix": prefix, "identifier": identifier, "name": name}, context=converter
         )
+
+    @classmethod
+    def from_reference(cls, reference: NamedReference, *, converter: Converter | None = None) -> Self:
+        """Parse a CURIE string and populate a reference.
+
+        :param reference: A pre-parsed reference
+        :param converter: The converter to use as context when parsing
+        :return: A reference object
+        """
+        return cls.model_validate({"prefix": reference.prefix, "identifier": reference.identifier, "name": reference.name}, context=converter)
+
 
 
 RecordKey = tuple[str, str, str, str]

--- a/src/curies/api.py
+++ b/src/curies/api.py
@@ -563,6 +563,9 @@ class NamedReference(NamableReference):
         :param reference: A pre-parsed reference
         :param converter: The converter to use as context when parsing
         :return: A reference object
+
+        :raises TypeError:
+            if a reference that has no name field is passed (e.g., a vanilla :class:`curies.Reference`)
         """
         if not isinstance(reference, NamableReference):
             raise TypeError(

--- a/src/curies/api.py
+++ b/src/curies/api.py
@@ -469,7 +469,9 @@ class Reference(BaseModel):
         :param converter: The converter to use as context when parsing
         :return: A reference object
         """
-        return cls.model_validate({"prefix": reference.prefix, "identifier": reference.identifier}, context=converter)
+        return cls.model_validate(
+            {"prefix": reference.prefix, "identifier": reference.identifier}, context=converter
+        )
 
 
 class NamableReference(Reference):
@@ -519,8 +521,10 @@ class NamableReference(Reference):
         :return: A reference object
         """
         name = reference.name if isinstance(reference, NamableReference) else None
-        return cls.model_validate({"prefix": reference.prefix, "identifier": reference.identifier, "name": name}, context=converter)
-
+        return cls.model_validate(
+            {"prefix": reference.prefix, "identifier": reference.identifier, "name": name},
+            context=converter,
+        )
 
 
 class NamedReference(NamableReference):
@@ -553,15 +557,23 @@ class NamedReference(NamableReference):
         )
 
     @classmethod
-    def from_reference(cls, reference: NamedReference, *, converter: Converter | None = None) -> Self:
+    def from_reference(
+        cls, reference: NamedReference, *, converter: Converter | None = None
+    ) -> Self:
         """Parse a CURIE string and populate a reference.
 
         :param reference: A pre-parsed reference
         :param converter: The converter to use as context when parsing
         :return: A reference object
         """
-        return cls.model_validate({"prefix": reference.prefix, "identifier": reference.identifier, "name": reference.name}, context=converter)
-
+        return cls.model_validate(
+            {
+                "prefix": reference.prefix,
+                "identifier": reference.identifier,
+                "name": reference.name,
+            },
+            context=converter,
+        )
 
 
 RecordKey = tuple[str, str, str, str]

--- a/src/curies/api.py
+++ b/src/curies/api.py
@@ -566,9 +566,6 @@ class NamedReference(NamableReference):
         """
         if not isinstance(reference, NamableReference):
             raise TypeError
-        if reference.name is None:
-            raise ValueError
-
         return cls.model_validate(
             {
                 "prefix": reference.prefix,

--- a/src/curies/api.py
+++ b/src/curies/api.py
@@ -565,7 +565,9 @@ class NamedReference(NamableReference):
         :return: A reference object
         """
         if not isinstance(reference, NamableReference):
-            raise TypeError
+            raise TypeError(
+                f"tried to construct a named reference from a non-named reference: {reference}"
+            )
         return cls.model_validate(
             {
                 "prefix": reference.prefix,


### PR DESCRIPTION
Add a function for re-constructing one reference from another.

This is useful for turning references defined in `curies.vocabulary` to subclasses