### PR TITLE
Remove deprecated return behavior

### DIFF
--- a/src/curies/api.py
+++ b/src/curies/api.py
@@ -1600,8 +1600,8 @@ class Converter:
     ) -> ReferenceTuple: ...
 
     def parse_uri(
-        self, uri: str, *, strict: bool = False, return_none: bool = False
-    ) -> ReferenceTuple | tuple[None, None] | None:
+        self, uri: str, *, strict: bool = False, return_none: bool = True
+    ) -> ReferenceTuple | None:
         """Compress a URI to a CURIE pair.
 
         :param uri:
@@ -1624,7 +1624,6 @@ class Converter:
         >>> converter.parse_uri("http://purl.obolibrary.org/obo/CHEBI_138488")
         ReferenceTuple(prefix='CHEBI', identifier='138488')
         >>> converter.parse_uri("http://example.org/missing:0000000")
-        (None, None)
         """
         rv = self.trie.parse_uri(uri)
         if rv is not None:
@@ -1633,11 +1632,9 @@ class Converter:
             raise CompressionError(uri) from None
         if return_none:
             return None
-        warnings.warn(
-            "Converter.parse_uri will switch to returning None instead of (None, None) in curies v0.11.0.",
-            stacklevel=2,
+        raise NotImplementedError(
+            "Converter.parse_uri stopped returning (None, None) in curies v0.11.0."
         )
-        return None, None
 
     def is_curie(self, s: str) -> bool:
         """Check if the string can be parsed as a CURIE by this converter.

--- a/src/curies/api.py
+++ b/src/curies/api.py
@@ -6,7 +6,6 @@ import csv
 import itertools as itt
 import json
 import logging
-import warnings
 from collections import UserDict, defaultdict
 from collections.abc import Callable, Collection, Iterable, Iterator, Mapping, Sequence
 from functools import partial
@@ -1580,13 +1579,7 @@ class Converter:
     # docstr-coverage:excused `overload`
     @overload
     def parse_uri(
-        self, uri: str, *, strict: Literal[False] = False, return_none: Literal[False] = False
-    ) -> ReferenceTuple | tuple[None, None]: ...
-
-    # docstr-coverage:excused `overload`
-    @overload
-    def parse_uri(
-        self, uri: str, *, strict: Literal[False] = False, return_none: Literal[True] = True
+        self, uri: str, *, strict: Literal[False] = False, return_none: bool = ...
     ) -> ReferenceTuple | None: ...
 
     # docstr-coverage:excused `overload`

--- a/src/curies/preprocessing.py
+++ b/src/curies/preprocessing.py
@@ -393,7 +393,7 @@ class PreprocessingConverter(Converter):
         return_none: bool = True,
         context: str | None = None,
         block_action: BlockAction = "raise",
-    ) -> ReferenceTuple | tuple[None, None] | None:
+    ) -> ReferenceTuple | None:
         """Parse and standardize a URI.
 
         :param uri: The URI to parse and standardize

--- a/src/curies/preprocessing.py
+++ b/src/curies/preprocessing.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from typing import Any, Literal, TypeAlias, TypeVar, overload
 
 from pydantic import BaseModel, Field
-from typing_extensions import Never, Self
+from typing_extensions import Self
 
 from .api import Converter, Reference, ReferenceTuple
 
@@ -356,19 +356,7 @@ class PreprocessingConverter(Converter):
         uri: str,
         *,
         strict: Literal[False] = False,
-        return_none: Literal[False] = False,
-        context: str | None = ...,
-        block_action: BlockAction = ...,
-    ) -> Never: ...
-
-    # docstr-coverage:excused `overload`
-    @overload
-    def parse_uri(
-        self,
-        uri: str,
-        *,
-        strict: Literal[False] = False,
-        return_none: Literal[True] = True,
+        return_none: bool = ...,
         context: str | None = ...,
         block_action: BlockAction = ...,
     ) -> ReferenceTuple | None: ...


### PR DESCRIPTION
Now, it's only possible to return `None` instead of a tuple of two `(None, None)`. If you're reusing the old style, now you'll get a `NotImplementedError` instead of a warning.