### PR TITLE
Generic prefix type

### DIFF
--- a/src/curies/api.py
+++ b/src/curies/api.py
@@ -77,12 +77,6 @@ logger = logging.getLogger(__name__)
 X = TypeVar("X")
 LocationOr: TypeAlias = str | Path | X
 
-RETURN_NONE_ERROR_TEXT = (
-    "Converter.parse_uri stopped returning ``(None, None)`` in curies v0.11.0. "
-    "``return_none`` is now a no-op argument (i.e., you shouldn't pass it "
-    "anymore) and the function returns ``None`` when parsing fails in non-strict mode"
-)
-
 
 def _get_field_validator_values(values: Any, key: str) -> str:
     """Get the value for the key from a field validator object."""
@@ -1790,9 +1784,7 @@ class Converter:
 
     # docstr-coverage:excused `overload`
     @overload
-    def parse_uri(
-        self, uri: str, *, strict: Literal[False] = ..., return_none: None = ...
-    ) -> ReferenceTuple | None: ...
+    def parse_uri(self, uri: str, *, strict: Literal[False] = ...) -> ReferenceTuple | None: ...
 
     # docstr-coverage:excused `overload`
     @overload
@@ -1801,24 +1793,18 @@ class Converter:
         uri: str,
         *,
         strict: Literal[True] = True,
-        return_none: None = ...,
     ) -> ReferenceTuple: ...
 
-    def parse_uri(
-        self, uri: str, *, strict: bool = False, return_none: None = None
-    ) -> ReferenceTuple | None:
+    def parse_uri(self, uri: str, *, strict: bool = False) -> ReferenceTuple | None:
         """Compress a URI to a CURIE pair.
 
         :param uri: A string representing a valid uniform resource identifier (URI)
         :param strict: If true and the URI can't be parsed, returns an error. Defaults
             to false.
-        :param return_none: Opt into future type returning of a single None instead of a
-            pair of Nones
 
         :returns: A CURIE pair if the URI could be parsed, otherwise a pair of None's
 
         :raises CompressionError: if strict is set to true and the URI can't be parsed
-        :raises NotImplementedError: If you pass ``False`` to return_none
 
         >>> from curies import Converter
         >>> converter = Converter.from_prefix_map(
@@ -1837,12 +1823,7 @@ class Converter:
             return rv
         if strict:
             raise CompressionError(uri) from None
-        if return_none is None:
-            return None
-        elif return_none is True:
-            raise NotImplementedError("return_none should not be passed as of curies v0.13.0")
-        else:  # i.e., return_none=False, which isn't supported anymore.
-            raise NotImplementedError(RETURN_NONE_ERROR_TEXT)
+        return None
 
     def is_curie(self, s: str) -> bool:
         """Check if the string can be parsed as a CURIE by this converter.

--- a/src/curies/api.py
+++ b/src/curies/api.py
@@ -15,10 +15,10 @@ from typing import (
     TYPE_CHECKING,
     Annotated,
     Any,
+    Generic,
     Literal,
     NamedTuple,
     TypeAlias,
-    TypeVar,
     cast,
     overload,
 )
@@ -33,7 +33,7 @@ from pydantic import (
     model_validator,
 )
 from pydantic_core import core_schema
-from typing_extensions import Self
+from typing_extensions import Self, TypeVar
 
 from .utils import NoCURIEDelimiterError, _split
 
@@ -53,6 +53,7 @@ __all__ = [
     "NoCURIEDelimiterError",
     "Prefix",
     "PrefixMap",
+    "PrefixType",
     "Record",
     "Records",
     "Reference",
@@ -389,7 +390,11 @@ class PrefixMap(RootModel[dict[Prefix, str]]):
     """
 
 
-class Reference(BaseModel):
+#: A type variable for prefixes which defaults to the simplest
+PrefixType: TypeAlias = TypeVar("PrefixType", bound=Prefix, default=Prefix)
+
+
+class Reference(BaseModel, Generic[PrefixType]):
     """A reference to an entity in a given identifier space.
 
     This class uses Pydantic to make it easier to build other more complex data types
@@ -432,7 +437,7 @@ class Reference(BaseModel):
     """
 
     prefix: Annotated[
-        Prefix,
+        PrefixType,
         Field(
             description="The prefix used in a compact URI (CURIE).",
         ),

--- a/src/curies/api.py
+++ b/src/curies/api.py
@@ -385,7 +385,7 @@ class PrefixMap(RootModel[dict[Prefix, str]]):
 
 
 #: A type variable for prefixes which defaults to the simplest
-PrefixType: TypeAlias = TypeVar("PrefixType", bound=Prefix, default=Prefix)
+PrefixType = TypeVar("PrefixType", bound=Prefix, default=Prefix)
 
 
 class Reference(BaseModel, Generic[PrefixType]):
@@ -486,7 +486,7 @@ class Reference(BaseModel, Generic[PrefixType]):
     # note that it's important that this is explicitly
     # Reference and not Self, since all subclasses should
     # return only a reference.
-    def without_name(self) -> Reference:
+    def without_name(self) -> Reference[PrefixType]:
         """Return this reference, since it already has no name."""
         return self
 

--- a/src/curies/preprocessing.py
+++ b/src/curies/preprocessing.py
@@ -8,10 +8,9 @@ from pathlib import Path
 from typing import Any, Literal, TypeAlias, TypeVar, overload
 
 from pydantic import BaseModel, Field
-from typing_extensions import Never, Self
+from typing_extensions import Self
 
 from .api import (
-    RETURN_NONE_ERROR_TEXT,
     Converter,
     Reference,
     ReferenceTuple,
@@ -361,19 +360,6 @@ class PreprocessingConverter(Converter):
         uri: str,
         *,
         strict: Literal[False] = ...,
-        return_none: Literal[False] = ...,
-        context: str | None = ...,
-        block_action: BlockAction = ...,
-    ) -> Never: ...
-
-    # docstr-coverage:excused `overload`
-    @overload
-    def parse_uri(
-        self,
-        uri: str,
-        *,
-        strict: Literal[False] = ...,
-        return_none: Literal[True] | None = ...,
         context: str | None = ...,
         block_action: BlockAction = ...,
     ) -> ReferenceTuple | None: ...
@@ -385,7 +371,6 @@ class PreprocessingConverter(Converter):
         uri: str,
         *,
         strict: Literal[True] = True,
-        return_none: bool | None = ...,
         context: str | None = ...,
         block_action: BlockAction = ...,
     ) -> ReferenceTuple: ...
@@ -395,7 +380,6 @@ class PreprocessingConverter(Converter):
         uri: str,
         *,
         strict: bool = False,
-        return_none: bool | None = None,
         context: str | None = None,
         block_action: BlockAction = "raise",
     ) -> ReferenceTuple | None:
@@ -404,8 +388,6 @@ class PreprocessingConverter(Converter):
         :param uri: The URI to parse and standardize
         :param strict: If the URI can't be parsed, should an error be thrown? Defaults
             to false.
-        :param return_none: A dummy value, do not use. If given as False, will raise a
-            not implemented error
         :param context: Is there a context, e.g., an ontology prefix that should be
             applied to the remapping and blocklist rules?
         :param block_action: What action should be taken when the blocklist is invoked?
@@ -416,11 +398,7 @@ class PreprocessingConverter(Converter):
         :returns: A tuple representing a parsed and standardized URI
 
         :raises BlocklistError: If the URI is blocked
-        :raises NotImplementedError: If return_none is given as False
         """
-        if return_none is False:
-            raise NotImplementedError(RETURN_NONE_ERROR_TEXT)
-
         uri = self._preclean(uri)
 
         if r1 := self.rules.remap_full(uri, reference_cls=self._reference_cls, context=context):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -952,10 +952,6 @@ class TestConverter(unittest.TestCase):
         self.assertEqual(ReferenceTuple("GO", "1234567"), converter.parse_uri(uri2, strict=True))
         self.assertEqual(ReferenceTuple("GO", "1234567"), converter.parse_uri(uri2, strict=False))
 
-        with self.assertRaises(NotImplementedError):
-            converter.parse_uri("123345", strict=False, return_none=False)  # type:ignore
-        with self.assertRaises(NotImplementedError):
-            converter.parse_uri("123345", strict=False, return_none=True)  # type:ignore
         self.assertIsNone(converter.parse_uri("123345", strict=False))
         with self.assertRaises(ValueError):
             converter.parse_uri("123345", strict=True)


### PR DESCRIPTION
This PR parametrizes the Reference class with a generic prefix type, which by default goes to `curies.Prefix`. This allows Reference to be subclassed with more specific prefix type