### PR TITLE
Fix fully specified triples in the mapping service

### DIFF
--- a/src/curies/mapping_service/api.py
+++ b/src/curies/mapping_service/api.py
@@ -116,6 +116,9 @@ class MappingServiceGraph(Graph):
                 objects = self._expand_pair_all(subj_query)
                 for obj, pred in itt.product(objects, self.query_predicates):
                     yield subj_query, pred, obj
+            elif subj_query is not None and obj_query is not None:
+                if obj_query in self._expand_pair_all(subj_query):
+                    yield subj_query, pred_query, obj_query
 
 
 def get_flask_mapping_blueprint(

--- a/tests/test_mapping_service.py
+++ b/tests/test_mapping_service.py
@@ -142,14 +142,30 @@ class TestMappingService(unittest.TestCase):
             # errors because of unknown URI
             "SELECT ?o WHERE { <http://example.com/1> owl:sameAs ?o }",
             "SELECT ?s WHERE { ?s owl:sameAs <http://example.com/1> }",
-            # errors because predicate is given
-            (
-                "SELECT * WHERE { <http://purl.obolibrary.org/obo/CHEBI_1> "
-                "owl:sameAs <http://purl.obolibrary.org/obo/CHEBI_1> }"
-            ),
         ]:
             with self.subTest(sparql=sparql):
                 self.assertEqual([], list(self.graph.query(sparql, processor=self.processor)))
+
+    def test_fully_specified_triple(self) -> None:
+        """Test fully specified mapping triples."""
+        matching_query = """\
+ASK WHERE {
+    <http://purl.obolibrary.org/obo/CHEBI_1>
+    owl:sameAs <http://identifiers.org/chebi/1>
+}
+"""
+        non_matching_query = """\
+ASK WHERE {
+    <http://purl.obolibrary.org/obo/CHEBI_1>
+    owl:sameAs <http://purl.obolibrary.org/obo/GO_1>
+}
+"""
+
+        matching_result = self.graph.query(matching_query, processor=self.processor)
+        non_matching_result = self.graph.query(non_matching_query, processor=self.processor)
+
+        self.assertTrue(matching_result.askAnswer)
+        self.assertFalse(non_matching_result.askAnswer)
 
     def test_sparql(self) -> None:
         """Test a sparql query on the graph."""


### PR DESCRIPTION
## Summary

- Handle subject-predicate-object queries where all three terms are bound.
- Yield the triple only when the requested object is one of the subject's valid expansions.
- Cover both matching and non-matching SPARQL `ASK` queries without changing partial-query behavior.

Closes #48

## Validation

- Mapping-service suite — 19 passed, 3 skipped, and 105 subtests passed.
- Ruff check and format passed on both touched files.
- `git diff --check`.

## Scope notes

The skipped cases are existing optional/service cases in the focused suite.